### PR TITLE
Cleanup pixel aliases

### DIFF
--- a/examples/multiwindows/main.go
+++ b/examples/multiwindows/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	pixel "github.com/gopxl/pixel/v2"
+	"github.com/gopxl/pixel/v2"
 	"github.com/gopxl/pixel/v2/pixelgl"
 	"github.com/gopxl/pixel/v2/text"
 )

--- a/examples/platformer/main.go
+++ b/examples/platformer/main.go
@@ -13,7 +13,7 @@ import (
 
 	_ "image/png"
 
-	pixel "github.com/gopxl/pixel/v2"
+	"github.com/gopxl/pixel/v2"
 	"github.com/gopxl/pixel/v2/imdraw"
 	"github.com/gopxl/pixel/v2/pixelgl"
 	"github.com/pkg/errors"

--- a/geometry_test.go
+++ b/geometry_test.go
@@ -3,7 +3,7 @@ package pixel_test
 import (
 	"testing"
 
-	pixel "github.com/gopxl/pixel/v2"
+	"github.com/gopxl/pixel/v2"
 )
 
 type sub struct {

--- a/pixelgl/window.go
+++ b/pixelgl/window.go
@@ -6,11 +6,11 @@ import (
 	"image/color"
 	"runtime"
 
-	pixel "github.com/gopxl/pixel/v2"
 	"github.com/faiface/glhf"
 	"github.com/faiface/mainthread"
 	"github.com/go-gl/gl/v3.3-core/gl"
 	"github.com/go-gl/glfw/v3.3/glfw"
+	"github.com/gopxl/pixel/v2"
 	"github.com/pkg/errors"
 )
 


### PR DESCRIPTION
Remove pixel package alias leftover from an intermediate name change. With the final naming scheme that we settled on it is not needed.