### PR TITLE
added ability to focus a window through API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Adding `Focus()` method to `Window` to focus the window via API.
 
 ## [v1.0.0](https://github.com/gopxl/pixel/v2/compare/v1.0.0...dev)
 - Multiple Window Management Framework

--- a/pixelgl/window.go
+++ b/pixelgl/window.go
@@ -527,6 +527,14 @@ func (w *Window) Show() {
 	})
 }
 
+// Focus makes the window focused, brings the specified window to front and sets input focus.
+// The window should already be visible and not iconified.
+func (w *Window) Focus() {
+	mainthread.Call(func() {
+		w.window.Focus()
+	})
+}
+
 // Hide hides the window, if it was previously visible. If the window is already
 // hidden or is in full screen mode, this function does nothing.
 


### PR DESCRIPTION
Related to #51, glfw adds this support.

Focus a window now by 
```go
win := pixelgl.NewWindow(...)

win.Focus()

fmt.Printf("%v\n", win.Focused()) // True
```