### PR TITLE
Experimenting with generics for backend type passthrough

### DIFF
--- a/backends/opengl/joystick.go
+++ b/backends/opengl/joystick.go
@@ -86,8 +86,10 @@ func (w *Window) JoystickAxisCount(js pixel.Joystick) int {
 //
 // This API is experimental.
 func (w *Window) JoystickPressed(js pixel.Joystick, button pixel.GamepadButton) bool {
-	b := gamepadButtonMapping[button]
-	return w.currJoy[js].Button(b) == glfw.Press
+	if b, ok := gamepadButtonMapping[button]; ok {
+		return w.currJoy[js].Button(b) == glfw.Press
+	}
+	return false
 }
 
 // JoystickJustPressed returns whether the joystick Button has just been pressed down.
@@ -95,8 +97,10 @@ func (w *Window) JoystickPressed(js pixel.Joystick, button pixel.GamepadButton) 
 //
 // This API is experimental.
 func (w *Window) JoystickJustPressed(js pixel.Joystick, button pixel.GamepadButton) bool {
-	b := gamepadButtonMapping[button]
-	return w.currJoy[js].Button(b) == glfw.Press && w.prevJoy[js].Button(b) != glfw.Press
+	if b, ok := gamepadButtonMapping[button]; ok {
+		return w.currJoy[js].Button(b) == glfw.Press && w.prevJoy[js].Button(b) != glfw.Press
+	}
+	return false
 }
 
 // JoystickJustReleased returns whether the joystick Button has just been released up.
@@ -104,8 +108,10 @@ func (w *Window) JoystickJustPressed(js pixel.Joystick, button pixel.GamepadButt
 //
 // This API is experimental.
 func (w *Window) JoystickJustReleased(js pixel.Joystick, button pixel.GamepadButton) bool {
-	b := gamepadButtonMapping[button]
-	return w.currJoy[js].Button(b) != glfw.Press && w.prevJoy[js].Button(b) == glfw.Press
+	if b, ok := gamepadButtonMapping[button]; ok {
+		return w.currJoy[js].Button(b) != glfw.Press && w.prevJoy[js].Button(b) == glfw.Press
+	}
+	return false
 }
 
 // JoystickAxis returns the value of a joystick axis at the last call to Window.Update.
@@ -113,8 +119,10 @@ func (w *Window) JoystickJustReleased(js pixel.Joystick, button pixel.GamepadBut
 //
 // This API is experimental.
 func (w *Window) JoystickAxis(js pixel.Joystick, axis pixel.GamepadAxis) float64 {
-	a := gamepadAxisMapping[axis]
-	return float64(w.currJoy[js].Axis(a))
+	if a, ok := gamepadAxisMapping[axis]; ok {
+		return float64(w.currJoy[js].Axis(a))
+	}
+	return 0
 }
 
 // Used internally during Window.UpdateInput to update the state of the joysticks.

--- a/backends/opengl/joystick.go
+++ b/backends/opengl/joystick.go
@@ -5,57 +5,57 @@ import (
 	"github.com/gopxl/pixel/v2"
 )
 
-var joystickMapping = map[glfw.Joystick]pixel.Joystick{
-	glfw.Joystick1:  pixel.Joystick1,
-	glfw.Joystick2:  pixel.Joystick2,
-	glfw.Joystick3:  pixel.Joystick3,
-	glfw.Joystick4:  pixel.Joystick4,
-	glfw.Joystick5:  pixel.Joystick5,
-	glfw.Joystick6:  pixel.Joystick6,
-	glfw.Joystick7:  pixel.Joystick7,
-	glfw.Joystick8:  pixel.Joystick8,
-	glfw.Joystick9:  pixel.Joystick9,
-	glfw.Joystick10: pixel.Joystick10,
-	glfw.Joystick11: pixel.Joystick11,
-	glfw.Joystick12: pixel.Joystick12,
-	glfw.Joystick13: pixel.Joystick13,
-	glfw.Joystick14: pixel.Joystick14,
-	glfw.Joystick15: pixel.Joystick15,
-	glfw.Joystick16: pixel.Joystick16,
+var joystickMapping = map[pixel.Joystick]glfw.Joystick{
+	pixel.Joystick1:  glfw.Joystick1,
+	pixel.Joystick2:  glfw.Joystick2,
+	pixel.Joystick3:  glfw.Joystick3,
+	pixel.Joystick4:  glfw.Joystick4,
+	pixel.Joystick5:  glfw.Joystick5,
+	pixel.Joystick6:  glfw.Joystick6,
+	pixel.Joystick7:  glfw.Joystick7,
+	pixel.Joystick8:  glfw.Joystick8,
+	pixel.Joystick9:  glfw.Joystick9,
+	pixel.Joystick10: glfw.Joystick10,
+	pixel.Joystick11: glfw.Joystick11,
+	pixel.Joystick12: glfw.Joystick12,
+	pixel.Joystick13: glfw.Joystick13,
+	pixel.Joystick14: glfw.Joystick14,
+	pixel.Joystick15: glfw.Joystick15,
+	pixel.Joystick16: glfw.Joystick16,
 }
 
 // Not currently used because Gamepad Axis/Button input works a bit different than others
-var _ = map[glfw.GamepadAxis]pixel.GamepadAxis{
-	glfw.AxisLeftX:        pixel.AxisLeftX,
-	glfw.AxisLeftY:        pixel.AxisLeftY,
-	glfw.AxisRightX:       pixel.AxisRightX,
-	glfw.AxisRightY:       pixel.AxisRightY,
-	glfw.AxisLeftTrigger:  pixel.AxisLeftTrigger,
-	glfw.AxisRightTrigger: pixel.AxisRightTrigger,
+var gamepadAxisMapping = map[pixel.GamepadAxis]glfw.GamepadAxis{
+	pixel.AxisLeftX:        glfw.AxisLeftX,
+	pixel.AxisLeftY:        glfw.AxisLeftY,
+	pixel.AxisRightX:       glfw.AxisRightX,
+	pixel.AxisRightY:       glfw.AxisRightY,
+	pixel.AxisLeftTrigger:  glfw.AxisLeftTrigger,
+	pixel.AxisRightTrigger: glfw.AxisRightTrigger,
 }
 
-var _ = map[glfw.GamepadButton]pixel.GamepadButton{
-	glfw.ButtonA:           pixel.GamepadA,
-	glfw.ButtonB:           pixel.GamepadB,
-	glfw.ButtonX:           pixel.GamepadX,
-	glfw.ButtonY:           pixel.GamepadY,
-	glfw.ButtonLeftBumper:  pixel.GamepadLeftBumper,
-	glfw.ButtonRightBumper: pixel.GamepadRightBumper,
-	glfw.ButtonBack:        pixel.GamepadBack,
-	glfw.ButtonStart:       pixel.GamepadStart,
-	glfw.ButtonGuide:       pixel.GamepadGuide,
-	glfw.ButtonLeftThumb:   pixel.GamepadLeftThumb,
-	glfw.ButtonRightThumb:  pixel.GamepadRightThumb,
-	glfw.ButtonDpadUp:      pixel.GamepadDpadUp,
-	glfw.ButtonDpadRight:   pixel.GamepadDpadRight,
-	glfw.ButtonDpadDown:    pixel.GamepadDpadDown,
-	glfw.ButtonDpadLeft:    pixel.GamepadDpadLeft,
+var gamepadButtonMapping = map[pixel.GamepadButton]glfw.GamepadButton{
+	pixel.GamepadA:           glfw.ButtonA,
+	pixel.GamepadB:           glfw.ButtonB,
+	pixel.GamepadX:           glfw.ButtonX,
+	pixel.GamepadY:           glfw.ButtonY,
+	pixel.GamepadLeftBumper:  glfw.ButtonLeftBumper,
+	pixel.GamepadRightBumper: glfw.ButtonRightBumper,
+	pixel.GamepadBack:        glfw.ButtonBack,
+	pixel.GamepadStart:       glfw.ButtonStart,
+	pixel.GamepadGuide:       glfw.ButtonGuide,
+	pixel.GamepadLeftThumb:   glfw.ButtonLeftThumb,
+	pixel.GamepadRightThumb:  glfw.ButtonRightThumb,
+	pixel.GamepadDpadUp:      glfw.ButtonDpadUp,
+	pixel.GamepadDpadRight:   glfw.ButtonDpadRight,
+	pixel.GamepadDpadDown:    glfw.ButtonDpadDown,
+	pixel.GamepadDpadLeft:    glfw.ButtonDpadLeft,
 }
 
 // JoystickPresent returns if the joystick is currently connected.
 //
 // This API is experimental.
-func (w *Window) JoystickPresent(js glfw.Joystick) bool {
+func (w *Window) JoystickPresent(js pixel.Joystick) bool {
 	return w.currJoy[js].Connected()
 }
 
@@ -63,21 +63,21 @@ func (w *Window) JoystickPresent(js glfw.Joystick) bool {
 // empty string.
 //
 // This API is experimental.
-func (w *Window) JoystickName(js glfw.Joystick) string {
+func (w *Window) JoystickName(js pixel.Joystick) string {
 	return w.currJoy[js].Name()
 }
 
 // JoystickButtonCount returns the number of buttons a connected joystick has.
 //
 // This API is experimental.
-func (w *Window) JoystickButtonCount(js glfw.Joystick) int {
+func (w *Window) JoystickButtonCount(js pixel.Joystick) int {
 	return w.currJoy[js].NumButtons()
 }
 
 // JoystickAxisCount returns the number of axes a connected joystick has.
 //
 // This API is experimental.
-func (w *Window) JoystickAxisCount(js glfw.Joystick) int {
+func (w *Window) JoystickAxisCount(js pixel.Joystick) int {
 	return w.currJoy[js].NumAxes()
 }
 
@@ -85,38 +85,42 @@ func (w *Window) JoystickAxisCount(js glfw.Joystick) int {
 // If the button index is out of range, this will return false.
 //
 // This API is experimental.
-func (w *Window) JoystickPressed(js glfw.Joystick, button glfw.GamepadButton) bool {
-	return w.currJoy[js].Button(button) == glfw.Press
+func (w *Window) JoystickPressed(js pixel.Joystick, button pixel.GamepadButton) bool {
+	b := gamepadButtonMapping[button]
+	return w.currJoy[js].Button(b) == glfw.Press
 }
 
 // JoystickJustPressed returns whether the joystick Button has just been pressed down.
 // If the button index is out of range, this will return false.
 //
 // This API is experimental.
-func (w *Window) JoystickJustPressed(js glfw.Joystick, button glfw.GamepadButton) bool {
-	return w.currJoy[js].Button(button) == glfw.Press && w.prevJoy[js].Button(button) != glfw.Press
+func (w *Window) JoystickJustPressed(js pixel.Joystick, button pixel.GamepadButton) bool {
+	b := gamepadButtonMapping[button]
+	return w.currJoy[js].Button(b) == glfw.Press && w.prevJoy[js].Button(b) != glfw.Press
 }
 
 // JoystickJustReleased returns whether the joystick Button has just been released up.
 // If the button index is out of range, this will return false.
 //
 // This API is experimental.
-func (w *Window) JoystickJustReleased(js glfw.Joystick, button glfw.GamepadButton) bool {
-	return w.currJoy[js].Button(button) != glfw.Press && w.prevJoy[js].Button(button) == glfw.Press
+func (w *Window) JoystickJustReleased(js pixel.Joystick, button pixel.GamepadButton) bool {
+	b := gamepadButtonMapping[button]
+	return w.currJoy[js].Button(b) != glfw.Press && w.prevJoy[js].Button(b) == glfw.Press
 }
 
 // JoystickAxis returns the value of a joystick axis at the last call to Window.Update.
 // If the axis index is out of range, this will return 0.
 //
 // This API is experimental.
-func (w *Window) JoystickAxis(js glfw.Joystick, axis glfw.GamepadAxis) float64 {
-	return float64(w.currJoy[js].Axis(axis))
+func (w *Window) JoystickAxis(js pixel.Joystick, axis pixel.GamepadAxis) float64 {
+	a := gamepadAxisMapping[axis]
+	return float64(w.currJoy[js].Axis(a))
 }
 
 // Used internally during Window.UpdateInput to update the state of the joysticks.
 func (w *Window) updateJoystickInput() {
-	for joystick := glfw.Joystick1; joystick <= glfw.JoystickLast; joystick++ {
-		js, ok := joystickMapping[joystick]
+	for js := pixel.Joystick1; js < pixel.Joystick(pixel.NumJoysticks); js++ {
+		joystick, ok := joystickMapping[js]
 		if !ok {
 			return
 		}

--- a/backends/opengl/joystick.go
+++ b/backends/opengl/joystick.go
@@ -130,7 +130,7 @@ func (w *Window) updateJoystickInput() {
 	for js := pixel.Joystick1; js < pixel.Joystick(pixel.NumJoysticks); js++ {
 		joystick, ok := joystickMapping[js]
 		if !ok {
-			return
+			continue
 		}
 		// Determine and store if the joystick was connected
 		joystickPresent := joystick.Present()

--- a/backends/opengl/window.go
+++ b/backends/opengl/window.go
@@ -108,7 +108,7 @@ type Window struct {
 	pressEvents, tempPressEvents     [pixel.NumButtons]bool
 	releaseEvents, tempReleaseEvents [pixel.NumButtons]bool
 
-	prevJoy, currJoy, tempJoy [glfw.JoystickLast + 1]pixel.Gamepad[glfw.Action, glfw.GamepadAxis, glfw.GamepadButton, float32]
+	prevJoy, currJoy, tempJoy [pixel.NumJoysticks]pixel.Gamepad[glfw.Action, glfw.GamepadAxis, glfw.GamepadButton, float32]
 }
 
 var currWin *Window

--- a/backends/opengl/window.go
+++ b/backends/opengl/window.go
@@ -108,7 +108,7 @@ type Window struct {
 	pressEvents, tempPressEvents     [pixel.NumButtons]bool
 	releaseEvents, tempReleaseEvents [pixel.NumButtons]bool
 
-	prevJoy, currJoy, tempJoy joystickState
+	prevJoy, currJoy, tempJoy [glfw.JoystickLast + 1]pixel.Gamepad[glfw.Action, glfw.GamepadAxis, glfw.GamepadButton, float32]
 }
 
 var currWin *Window

--- a/gamepad.go
+++ b/gamepad.go
@@ -1,11 +1,5 @@
 package pixel
 
-func NewGamepad[Action, Axis, Button ~int, AxisValue comparable](name string) *Gamepad[Action, Axis, Button, AxisValue] {
-	return &Gamepad[Action, Axis, Button, AxisValue]{
-		name: name,
-	}
-}
-
 type Gamepad[Action, Axis, Button ~int, AxisValue comparable] struct {
 	connected bool
 	name      string

--- a/gamepad.go
+++ b/gamepad.go
@@ -1,0 +1,57 @@
+package pixel
+
+func NewGamepad[Action, Axis, Button ~int, AxisValue comparable](name string) *Gamepad[Action, Axis, Button, AxisValue] {
+	return &Gamepad[Action, Axis, Button, AxisValue]{
+		name: name,
+	}
+}
+
+type Gamepad[Action, Axis, Button ~int, AxisValue comparable] struct {
+	connected bool
+	name      string
+	buttons   []Action
+	axes      []AxisValue
+}
+
+func (g *Gamepad[Action, Axis, Button, AxisValue]) Axis(axis Axis) AxisValue {
+	return g.axes[axis]
+}
+
+func (g *Gamepad[Action, Axis, Button, AxisValue]) Button(button Button) Action {
+	if button >= Button(len(g.buttons)) || button < 0 {
+		return -1
+	}
+	return g.buttons[button]
+}
+
+func (g *Gamepad[Action, Axis, Button, AxisValue]) Connected() bool {
+	return g.connected
+}
+
+func (g *Gamepad[Action, Axis, Button, AxisValue]) Name() string {
+	return g.name
+}
+
+func (g *Gamepad[Action, Axis, Button, AxisValue]) NumAxes() int {
+	return len(g.axes)
+}
+
+func (g *Gamepad[Action, Axis, Button, AxisValue]) NumButtons() int {
+	return len(g.buttons)
+}
+
+func (g *Gamepad[Action, Axis, Button, AxisValue]) SetAxes(axes []AxisValue) {
+	g.axes = axes
+}
+
+func (g *Gamepad[Action, Axis, Button, AxisValue]) SetButtons(buttons []Action) {
+	g.buttons = buttons
+}
+
+func (g *Gamepad[Action, Axis, Button, AxisValue]) SetConnected(connected bool) {
+	g.connected = connected
+}
+
+func (g *Gamepad[Action, Axis, Button, AxisValue]) SetName(name string) {
+	g.name = name
+}


### PR DESCRIPTION
This is an alternative implementation to https://github.com/gopxl/pixel/pull/76
And more importantly, an experiment in a different way to handle pixel's interactions with backends.

While working on the pixel Actions PR, it began to feel a bit like a hat on a hat on a hat as input arrays are passed up through the stack (OpenGL -> GLFW -> Pixel), copying at each level and creating more garbage to be collected. So I started experimenting with generics to see if I could get around that.

The idea is to store inputs in the backend's native type, and then when the user checks an input `win.Pressed(pixel.MouseButton1)` we do the mapping  from pixel -> backend type instead of the other way around.