### PR TITLE
Move input state out of backend into pixel core

### DIFF
--- a/backends/opengl/input.go
+++ b/backends/opengl/input.go
@@ -219,7 +219,7 @@ func (w *Window) initInput() {
 		w.window.SetMouseButtonCallback(func(_ *glfw.Window, button glfw.MouseButton, action glfw.Action, mod glfw.ModifierKey) {
 			if b, buttonOk := mouseButtonMapping[button]; buttonOk {
 				if a, actionOk := actionMapping[action]; actionOk {
-					w.input.SetButton(b, a)
+					w.input.ButtonEvent(b, a)
 				}
 			}
 		})
@@ -230,7 +230,7 @@ func (w *Window) initInput() {
 			}
 			if b, buttonOk := keyButtonMapping[key]; buttonOk {
 				if a, actionOk := actionMapping[action]; actionOk {
-					w.input.SetButton(b, a)
+					w.input.ButtonEvent(b, a)
 				}
 			}
 		})

--- a/backends/opengl/input.go
+++ b/backends/opengl/input.go
@@ -64,6 +64,10 @@ func (w *Window) MouseScroll() pixel.Vec {
 	return w.input.MouseScroll()
 }
 
+func (w *Window) MousePreviousScroll() pixel.Vec {
+	return w.input.MousePreviousScroll()
+}
+
 // Typed returns the text typed on the keyboard since the last call to Window.Update.
 func (w *Window) Typed() string {
 	return w.input.Typed()

--- a/backends/opengl/window.go
+++ b/backends/opengl/window.go
@@ -97,17 +97,7 @@ type Window struct {
 		xpos, ypos, width, height int
 	}
 
-	prevInp, currInp, tempInp struct {
-		mouse   pixel.Vec
-		buttons [pixel.NumButtons]bool
-		repeat  [pixel.NumButtons]bool
-		scroll  pixel.Vec
-		typed   string
-	}
-
-	pressEvents, tempPressEvents     [pixel.NumButtons]bool
-	releaseEvents, tempReleaseEvents [pixel.NumButtons]bool
-
+	input                     *pixel.InputHandler
 	prevJoy, currJoy, tempJoy joystickState
 }
 
@@ -122,7 +112,7 @@ func NewWindow(cfg WindowConfig) (*Window, error) {
 		false: glfw.False,
 	}
 
-	w := &Window{bounds: cfg.Bounds, cursorVisible: true}
+	w := &Window{bounds: cfg.Bounds, cursorVisible: true, input: &pixel.InputHandler{}}
 
 	flag := false
 	for _, v := range []int{0, 2, 4, 8, 16} {

--- a/input.go
+++ b/input.go
@@ -37,20 +37,6 @@ func (ih *InputHandler) Repeated(button Button) bool {
 	return ih.currInp.repeat[button]
 }
 
-// SetButton sets the action state of a button for the next update
-func (ih *InputHandler) SetButton(button Button, action Action) {
-	switch action {
-	case Press:
-		ih.tempPressEvents[button] = true
-		ih.tempInp.buttons[button] = true
-	case Release:
-		ih.tempReleaseEvents[button] = true
-		ih.tempInp.buttons[button] = false
-	case Repeat:
-		ih.tempInp.repeat[button] = true
-	}
-}
-
 // MousePosition returns the current mouse position in the Window's Bounds
 func (ih *InputHandler) MousePosition() Vec {
 	return ih.currInp.mouse
@@ -87,6 +73,20 @@ func (ih *InputHandler) SetMousePosition(pos Vec) {
 	ih.prevInp.mouse = pos
 	ih.currInp.mouse = pos
 	ih.tempInp.mouse = pos
+}
+
+// ButtonEvent sets the action state of a button for the next update
+func (ih *InputHandler) ButtonEvent(button Button, action Action) {
+	switch action {
+	case Press:
+		ih.tempPressEvents[button] = true
+		ih.tempInp.buttons[button] = true
+	case Release:
+		ih.tempReleaseEvents[button] = true
+		ih.tempInp.buttons[button] = false
+	case Repeat:
+		ih.tempInp.repeat[button] = true
+	}
 }
 
 // MouseMoveEvent sets the mouse position for the next update

--- a/input.go
+++ b/input.go
@@ -1,5 +1,130 @@
 package pixel
 
+type InputHandler struct {
+	prevInp, currInp, tempInp struct {
+		mouse   Vec
+		buttons [NumButtons]bool
+		repeat  [NumButtons]bool
+		scroll  Vec
+		typed   string
+	}
+
+	pressEvents, tempPressEvents     [NumButtons]bool
+	releaseEvents, tempReleaseEvents [NumButtons]bool
+
+	mouseInsideWindow bool
+}
+
+// Pressed returns whether the Button is currently pressed down.
+func (ih *InputHandler) Pressed(button Button) bool {
+	return ih.currInp.buttons[button]
+}
+
+// JustPressed returns whether the Button has been pressed in the last frame.
+func (ih *InputHandler) JustPressed(button Button) bool {
+	return ih.pressEvents[button]
+}
+
+// JustReleased returns whether the Button has been released in the last frame.
+func (ih *InputHandler) JustReleased(button Button) bool {
+	return ih.releaseEvents[button]
+}
+
+// Repeated returns whether a repeat event has been triggered on button.
+//
+// Repeat event occurs repeatedly when a button is held down for some time.
+func (ih *InputHandler) Repeated(button Button) bool {
+	return ih.currInp.repeat[button]
+}
+
+// SetButton sets the action state of a button for the next update
+func (ih *InputHandler) SetButton(button Button, action Action) {
+	switch action {
+	case Press:
+		ih.tempPressEvents[button] = true
+		ih.tempInp.buttons[button] = true
+	case Release:
+		ih.tempReleaseEvents[button] = true
+		ih.tempInp.buttons[button] = false
+	case Repeat:
+		ih.tempInp.repeat[button] = true
+	}
+}
+
+// MousePosition returns the current mouse position in the Window's Bounds
+func (ih *InputHandler) MousePosition() Vec {
+	return ih.currInp.mouse
+}
+
+// MousePreviousPosition returns the previous mouse position in the Window's Bounds
+func (ih *InputHandler) MousePreviousPosition() Vec {
+	return ih.prevInp.mouse
+}
+
+// MouseScroll returns the mouse scroll amount (in both axes) since the last update
+func (ih *InputHandler) MouseScroll() Vec {
+	return ih.currInp.scroll
+}
+
+// MousePreviousScroll returns the previous mouse scroll amount (in both axes)
+func (ih *InputHandler) MousePreviousScroll() Vec {
+	return ih.prevInp.scroll
+}
+
+// MouseInsideWindow returns true if the mouse position is within the Window's Bounds
+func (ih *InputHandler) MouseInsideWindow() bool {
+	return ih.mouseInsideWindow
+}
+
+// Typed returns the text typed on the keyboard since the last update
+func (ih *InputHandler) Typed() string {
+	return ih.currInp.typed
+}
+
+// SetMousePosition overrides the mouse position
+// Called when the mouse is set to a point in the backend Window
+func (ih *InputHandler) SetMousePosition(pos Vec) {
+	ih.prevInp.mouse = pos
+	ih.currInp.mouse = pos
+	ih.tempInp.mouse = pos
+}
+
+// MouseMoveEvent sets the mouse position for the next update
+func (ih *InputHandler) MouseMoveEvent(pos Vec) {
+	ih.tempInp.mouse = pos
+}
+
+// MouseScrollEvent adds to the scroll offset for the next update
+func (ih *InputHandler) MouseScrollEvent(x, y float64) {
+	ih.tempInp.scroll.X += x
+	ih.tempInp.scroll.Y += y
+}
+
+// MouseEnteredEvent is called when the mouse enters or leaves the window
+func (ih *InputHandler) MouseEnteredEvent(entered bool) {
+	ih.mouseInsideWindow = entered
+}
+
+// CharEvent adds to the typed string for the next update
+func (ih *InputHandler) CharEvent(r rune) {
+	ih.tempInp.typed += string(r)
+}
+
+func (ih *InputHandler) Update() {
+	ih.prevInp = ih.currInp
+	ih.currInp = ih.tempInp
+
+	ih.pressEvents = ih.tempPressEvents
+	ih.releaseEvents = ih.tempReleaseEvents
+
+	// Clear last frame's temporary status
+	ih.tempPressEvents = [NumButtons]bool{}
+	ih.tempReleaseEvents = [NumButtons]bool{}
+	ih.tempInp.repeat = [NumButtons]bool{}
+	ih.tempInp.scroll = ZV
+	ih.tempInp.typed = ""
+}
+
 type Action int
 
 // String returns a human-readable string describing the Button.


### PR DESCRIPTION
Continuing to separate core window functionality from the backend.

This moves the input state storage and handling into its own struct which will be called by backends when input events are detected.