### PR TITLE
Input events

### DIFF
--- a/backends/opengl/input.go
+++ b/backends/opengl/input.go
@@ -236,7 +236,7 @@ func (w *Window) initInput() {
 		})
 
 		w.window.SetCursorEnterCallback(func(_ *glfw.Window, entered bool) {
-			w.cursorInsideWindow = entered
+			w.input.MouseEnteredEvent(entered)
 		})
 
 		w.window.SetCursorPosCallback(func(_ *glfw.Window, x, y float64) {

--- a/backends/opengl/window.go
+++ b/backends/opengl/window.go
@@ -98,6 +98,12 @@ type Window struct {
 
 	input                     *pixel.InputHandler
 	prevJoy, currJoy, tempJoy joystickState
+
+	buttonCallback       func(win *Window, button pixel.Button, action pixel.Action)
+	charCallback         func(win *Window, r rune)
+	mouseEnteredCallback func(win *Window, entered bool)
+	mouseMovedCallback   func(win *Window, pos pixel.Vec)
+	scrollCallback       func(win *Window, scroll pixel.Vec)
 }
 
 var currWin *Window

--- a/backends/opengl/window.go
+++ b/backends/opengl/window.go
@@ -86,11 +86,10 @@ type WindowConfig struct {
 type Window struct {
 	window *glfw.Window
 
-	bounds             pixel.Rect
-	canvas             *Canvas
-	vsync              bool
-	cursorVisible      bool
-	cursorInsideWindow bool
+	bounds        pixel.Rect
+	canvas        *Canvas
+	vsync         bool
+	cursorVisible bool
 
 	// need to save these to correctly restore a fullscreen window
 	restore struct {


### PR DESCRIPTION
Adding support for callbacks on window events.

Ended up deciding to go with a really simple system for this to avoid adding unnecessary overhead or restricting how callbacks are processed. A single callback function can be set for each supported type of window event (button, char, mouse enter/exit, mouse move, scroll). If users want to add additional structure to their event handlers (e.g. lists/trees of callback handlers), process events async, etc. then that is left up to them to implement.