### PR TITLE
Color refactor

### DIFF
--- a/backends/opengl/canvas.go
+++ b/backends/opengl/canvas.go
@@ -193,24 +193,20 @@ func setBlendFunc(cmp pixel.ComposeMethod) {
 func (c *Canvas) Clear(color color.Color) {
 	c.gf.Dirty()
 
-	rgba := pixel.ToRGBA(color)
-
-	// color masking
-	rgba = rgba.Mul(pixel.RGBA{
-		R: float64(c.col[0]),
-		G: float64(c.col[1]),
-		B: float64(c.col[2]),
-		A: float64(c.col[3]),
-	})
+	r, g, b, a := pixel.ColorToFloats[float32](
+		pixel.ToRGBA(color).Mul(
+			pixel.FloatsToColor(c.col[0], c.col[1], c.col[2], c.col[3]),
+		),
+	)
 
 	mainthread.CallNonBlock(func() {
 		c.setGlhfBounds()
 		c.gf.Frame().Begin()
 		glhf.Clear(
-			float32(rgba.R),
-			float32(rgba.G),
-			float32(rgba.B),
-			float32(rgba.A),
+			r,
+			g,
+			b,
+			a,
 		)
 		c.gf.Frame().End()
 	})

--- a/backends/opengl/color.go
+++ b/backends/opengl/color.go
@@ -1,0 +1,26 @@
+package opengl
+
+import (
+	"image/color"
+
+	"github.com/go-gl/mathgl/mgl32"
+)
+
+type GLColor mgl32.Vec4
+
+func (c GLColor) RGBA() (r, g, b, a uint32) {
+	return uint32(c[0] * 0xffff), uint32(c[1] * 0xffff), uint32(c[2] * 0xffff), uint32(c[3] * 0xffff)
+}
+
+func ToGLColor(col color.Color) GLColor {
+	if c, ok := col.(GLColor); ok {
+		return c
+	}
+	r, g, b, a := col.RGBA()
+	return GLColor{
+		float32(r) / 0xffff,
+		float32(g) / 0xffff,
+		float32(b) / 0xffff,
+		float32(a) / 0xffff,
+	}
+}

--- a/backends/opengl/glframe.go
+++ b/backends/opengl/glframe.go
@@ -79,10 +79,10 @@ func (gf *GLFrame) Color(at pixel.Vec) pixel.RGBA {
 	x, y := int(at.X)-bx, int(at.Y)-by
 	off := y*bw + x
 	return pixel.RGBA{
-		R: float64(gf.pixels[off*4+0]) / 255,
-		G: float64(gf.pixels[off*4+1]) / 255,
-		B: float64(gf.pixels[off*4+2]) / 255,
-		A: float64(gf.pixels[off*4+3]) / 255,
+		R: gf.pixels[off*4+0],
+		G: gf.pixels[off*4+1],
+		B: gf.pixels[off*4+2],
+		A: gf.pixels[off*4+3],
 	}
 }
 

--- a/backends/opengl/glpicture.go
+++ b/backends/opengl/glpicture.go
@@ -90,9 +90,9 @@ func (gp *glPicture) Color(at pixel.Vec) pixel.RGBA {
 	x, y := int(at.X)-bx, int(at.Y)-by
 	off := y*bw + x
 	return pixel.RGBA{
-		R: float64(gp.pixels[off*4+0]) / 255,
-		G: float64(gp.pixels[off*4+1]) / 255,
-		B: float64(gp.pixels[off*4+2]) / 255,
-		A: float64(gp.pixels[off*4+3]) / 255,
+		R: gp.pixels[off*4+0],
+		G: gp.pixels[off*4+1],
+		B: gp.pixels[off*4+2],
+		A: gp.pixels[off*4+3],
 	}
 }

--- a/backends/opengl/gltriangles.go
+++ b/backends/opengl/gltriangles.go
@@ -127,19 +127,20 @@ func (gt *GLTriangles) updateData(t pixel.Triangles) {
 	if t, ok := t.(*pixel.TrianglesData); ok {
 		for i := 0; i < length; i++ {
 			var (
-				px, py = (*t)[i].Position.XY()
-				col    = (*t)[i].Color
-				tx, ty = (*t)[i].Picture.XY()
-				in     = (*t)[i].Intensity
-				rec    = (*t)[i].ClipRect
+				px, py     = (*t)[i].Position.XY()
+				col        = (*t)[i].Color
+				tx, ty     = (*t)[i].Picture.XY()
+				in         = (*t)[i].Intensity
+				rec        = (*t)[i].ClipRect
+				r, g, b, a = pixel.ColorToFloats[float32](col)
 			)
 			d := gt.data[i*stride : i*stride+trisAttrLen]
 			d[triPosX] = float32(px)
 			d[triPosY] = float32(py)
-			d[triColorR] = float32(col.R)
-			d[triColorG] = float32(col.G)
-			d[triColorB] = float32(col.B)
-			d[triColorA] = float32(col.A)
+			d[triColorR] = r
+			d[triColorG] = g
+			d[triColorB] = b
+			d[triColorA] = a
 			d[triPicX] = float32(tx)
 			d[triPicY] = float32(ty)
 			d[triIntensity] = float32(in)
@@ -251,12 +252,7 @@ func (gt *GLTriangles) Color(i int) pixel.RGBA {
 	g := gt.data[gt.index(i, triColorG)]
 	b := gt.data[gt.index(i, triColorB)]
 	a := gt.data[gt.index(i, triColorA)]
-	return pixel.RGBA{
-		R: float64(r),
-		G: float64(g),
-		B: float64(b),
-		A: float64(a),
-	}
+	return pixel.FloatsToColor(r, g, b, a)
 }
 
 // SetColor sets the color property of the i-th vertex.

--- a/color_test.go
+++ b/color_test.go
@@ -1,0 +1,54 @@
+package pixel
+
+import (
+	"image/color"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestColorConversions(t *testing.T) {
+	c0 := RGBA{64, 127, 128, 255}
+	c1 := FloatsToColor(ColorToFloats[float32](c0))
+	require.Equal(t, c0, c1)
+}
+
+func TestToRGBA(t *testing.T) {
+	type args struct {
+		c color.Color
+	}
+	tests := []struct {
+		name string
+		args args
+		want RGBA
+	}{
+		{
+			name: "pixel.rgba",
+			args: args{c: RGBA{64, 127, 128, 255}},
+			want: RGBA{64, 127, 128, 255},
+		},
+		{
+			name: "color.rgba",
+			args: args{c: color.RGBA{64, 127, 128, 255}},
+			want: RGBA{64, 127, 128, 255},
+		},
+		{
+			name: "color.nrgba",
+			args: args{c: color.NRGBA{64, 127, 128, 255}},
+			want: RGBA{64, 127, 128, 255},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ToRGBA(tt.args.c); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ToRGBA() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRGB(t *testing.T) {
+	rgba := RGB(0.25, 0.5, 0.75)
+	require.Equal(t, RGBA{63, 127, 191, 255}, rgba)
+}

--- a/compose.go
+++ b/compose.go
@@ -1,6 +1,9 @@
 package pixel
 
-import "errors"
+import (
+	"errors"
+	"image/color"
+)
 
 // ComposeTarget is a BasicTarget capable of Porter-Duff composition.
 type ComposeTarget interface {
@@ -31,28 +34,34 @@ const (
 
 // Compose composes two colors together according to the ComposeMethod. A is the foreground, B is
 // the background.
-func (cm ComposeMethod) Compose(a, b RGBA) RGBA {
+func (cm ComposeMethod) Compose(a, b color.Color) RGBA {
 	var fa, fb float64
+
+	ac := ToRGBA(a)
+	bc := ToRGBA(b)
+
+	aa := float64(ac.A) / 255
+	ba := float64(bc.A) / 255
 
 	switch cm {
 	case ComposeOver:
-		fa, fb = 1, 1-a.A
+		fa, fb = 1, 1-aa
 	case ComposeIn:
-		fa, fb = b.A, 0
+		fa, fb = ba, 0
 	case ComposeOut:
-		fa, fb = 1-b.A, 0
+		fa, fb = 1-ba, 0
 	case ComposeAtop:
-		fa, fb = b.A, 1-a.A
+		fa, fb = ba, 1-aa
 	case ComposeRover:
-		fa, fb = 1-b.A, 1
+		fa, fb = 1-ba, 1
 	case ComposeRin:
-		fa, fb = 0, a.A
+		fa, fb = 0, aa
 	case ComposeRout:
-		fa, fb = 0, 1-a.A
+		fa, fb = 0, 1-aa
 	case ComposeRatop:
-		fa, fb = 1-b.A, a.A
+		fa, fb = 1-ba, aa
 	case ComposeXor:
-		fa, fb = 1-b.A, 1-a.A
+		fa, fb = 1-ba, 1-aa
 	case ComposePlus:
 		fa, fb = 1, 1
 	case ComposeCopy:
@@ -61,5 +70,5 @@ func (cm ComposeMethod) Compose(a, b RGBA) RGBA {
 		panic(errors.New("Compose: invalid ComposeMethod"))
 	}
 
-	return a.Mul(Alpha(fa)).Add(b.Mul(Alpha(fb)))
+	return ac.Mul(Alpha(fa)).Add(bc.Mul(Alpha(fb)))
 }

--- a/ext/imdraw/imdraw.go
+++ b/ext/imdraw/imdraw.go
@@ -128,13 +128,8 @@ func (imd *IMDraw) Draw(t pixel.Target) {
 // Push adds some points to the IM queue. All Pushed points will have the same properties except for
 // the position.
 func (imd *IMDraw) Push(pts ...pixel.Vec) {
-	// Assert that Color is of type pixel.RGBA,
-	if _, ok := imd.Color.(pixel.RGBA); !ok {
-		// otherwise cast it
-		imd.Color = pixel.ToRGBA(imd.Color)
-	}
 	opts := point{
-		col:       imd.Color.(pixel.RGBA),
+		col:       pixel.ToRGBA(imd.Color),
 		pic:       imd.Picture,
 		in:        imd.Intensity,
 		precision: imd.Precision,

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/gopxl/mainthread/v2 v2.0.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
+	golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa
 	golang.org/x/image v0.13.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -18,6 +18,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa h1:ELnwvuAXPNtPk1TJRuGkI9fDTwym6AYBu0qzT8AcHdI=
+golang.org/x/exp v0.0.0-20240808152545-0cdaa3abc0fa/go.mod h1:akd2r19cwCdwSwWeIdzYQGa/EZZyqcOdwWiwj5L5eKQ=
 golang.org/x/image v0.0.0-20190321063152-3fc05d484e9f/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
 golang.org/x/image v0.13.0 h1:3cge/F/QTkNLauhf2QoE9zp+7sr+ZcL4HnoZmdwg9sg=
 golang.org/x/image v0.13.0/go.mod h1:6mmbMOeV28HuMTgA6OSRkdXKYw/t5W9Uwn2Yv1r3Yxk=

--- a/sprite.go
+++ b/sprite.go
@@ -1,6 +1,8 @@
 package pixel
 
-import "image/color"
+import (
+	"image/color"
+)
 
 // Sprite is a drawable frame of a Picture. It's anchored by the center of it's Picture's frame.
 //


### PR DESCRIPTION
Refactor the `pixel.RGBA` to be an alias of `color.RGBA` so that it's less data to move around and better integrated with the standard library.

Also, adds an implicit contract with the caller.
- If a function takes a color, it should be a `color.Color`.
- If a function returns a color, it will be a `pixel.RGBA` (alias for `color.RGBA`.

Addresses: #71