### PR TITLE
Set cursor on entered instead of every update

### DIFF
--- a/backends/opengl/input.go
+++ b/backends/opengl/input.go
@@ -262,6 +262,9 @@ func (w *Window) initInput() {
 		})
 
 		w.window.SetCursorEnterCallback(func(_ *glfw.Window, entered bool) {
+			if entered && w.cursor != nil {
+				w.window.SetCursor(w.cursor)
+			}
 			w.input.MouseEnteredEvent(entered)
 			if w.mouseEnteredCallback != nil {
 				w.mouseEnteredCallback(w, entered)

--- a/backends/opengl/window.go
+++ b/backends/opengl/window.go
@@ -230,7 +230,6 @@ func (w *Window) Destroy() {
 
 // Update swaps buffers and polls events. Call this method at the end of each frame.
 func (w *Window) Update() {
-	w.SetCursor(w.cursor)
 	w.SwapBuffers()
 	w.UpdateInput()
 }


### PR DESCRIPTION
@MarkKremer noted that cursor was being set on every frame. I did some experimenting and it looks like we can get away with just setting it on window enter event.