### PR TITLE
Revert "Fix text anchor position when txt.Bounds().W() != txt.Dot.X-txt.Orig.X"

### DIFF
--- a/ext/text/text.go
+++ b/ext/text/text.go
@@ -258,7 +258,7 @@ func (txt *Text) DrawColorMask(t pixel.Target, matrix pixel.Matrix, mask color.C
 		txt.dirty = true
 	}
 
-	offset := txt.Orig.Sub(txt.Bounds().Max.Add(txt.Bounds().AnchorPos(txt.anchor.Opposite())))
+	offset := txt.Bounds().AnchorPos(txt.anchor)
 	txt.mat = pixel.IM.Moved(offset).Chained(txt.mat)
 
 	if mask == nil {


### PR DESCRIPTION
Fix for https://github.com/gopxl/pixel/issues/84

This reverts commit 3b599e70ec9947a7942791a8f82cad766dd165f2.

With the previous change in place, text was not being properly aligned to the Dot position
![image](https://github.com/user-attachments/assets/6d6c5d15-c4a0-4f71-9547-96fab4dc0953)

With that line reverted, the typewriter example works properly
![image](https://github.com/user-attachments/assets/4e653fe3-40b0-4286-9585-ee5714675529)


Not entirely clear to me what the change was attempting to fix, but I have been unable to find a scenario where that offset calc is correct. Still need to do some work on text anchoring in general, as I don't think it is completely functional yet.