### PR TITLE
Text anchoring fixes

### DIFF
--- a/ext/text/text.go
+++ b/ext/text/text.go
@@ -381,8 +381,20 @@ func (txt *Text) drawBuf() {
 			continue
 		}
 
+		var dot pixel.Vec
 		var rect, frame, bounds pixel.Rect
-		rect, frame, bounds, txt.Dot = txt.Atlas().DrawRune(txt.prevR, r, txt.Dot)
+		rect, frame, bounds, dot = txt.Atlas().DrawRune(txt.prevR, r, txt.Dot)
+		if r == ' ' {
+			// Space character has empty bounds for some fonts
+			if bounds.W() == 0 {
+				bounds.Max = bounds.Max.Add(dot.Sub(txt.Dot))
+			}
+			if bounds.H() == 0 {
+				bounds.Min = txt.Dot
+				bounds.Max.Y += txt.atlas.lineHeight
+			}
+		}
+		txt.Dot = dot
 
 		txt.prevR = r
 

--- a/ext/text/text.go
+++ b/ext/text/text.go
@@ -205,6 +205,7 @@ func (txt *Text) Unaligned() *Text {
 	return txt
 }
 
+// AnchoredBounds returns the text bounds with the anchoring offset applied
 func (txt *Text) AnchoredBounds() pixel.Rect {
 	if !txt.isAnchored {
 		return txt.bounds
@@ -212,6 +213,7 @@ func (txt *Text) AnchoredBounds() pixel.Rect {
 	return txt.bounds.Moved(txt.AnchoredOffset())
 }
 
+// AnchoredDot returns text.Dot with the anchoring offset applied
 func (txt *Text) AnchoredDot() pixel.Vec {
 	if !txt.isAnchored {
 		return txt.Dot
@@ -219,6 +221,9 @@ func (txt *Text) AnchoredDot() pixel.Vec {
 	return txt.AnchoredOffset().Add(txt.Dot)
 }
 
+// AnchoredOffset calculates the position offset for the text based on it's anchor
+//
+// Text is anchored relative to the Orig
 func (txt *Text) AnchoredOffset() pixel.Vec {
 	if !txt.isAnchored {
 		return pixel.ZV

--- a/ext/text/text.go
+++ b/ext/text/text.go
@@ -334,6 +334,12 @@ func (txt *Text) controlRune(r rune, dot pixel.Vec) (newDot pixel.Vec, control b
 	case '\n':
 		dot.X = txt.Orig.X
 		dot.Y -= txt.LineHeight
+		if txt.bounds.Empty() {
+			txt.bounds.Min = dot
+			txt.bounds.Max = txt.Orig.Add(pixel.V(0.01, txt.atlas.lineHeight))
+		} else {
+			txt.bounds.Min.Y -= txt.LineHeight
+		}
 	case '\r':
 		dot.X = txt.Orig.X
 	case '\t':
@@ -343,6 +349,12 @@ func (txt *Text) controlRune(r rune, dot pixel.Vec) (newDot pixel.Vec, control b
 			rem = txt.TabWidth
 		}
 		dot.X += rem
+		if txt.bounds.Empty() {
+			txt.bounds.Min = txt.Dot
+			txt.bounds.Max = pixel.V(dot.X, txt.Orig.Y+txt.atlas.lineHeight)
+		} else if dot.X > txt.bounds.Max.X {
+			txt.bounds.Max.X = dot.X
+		}
 	default:
 		return dot, false
 	}

--- a/ext/text/text.go
+++ b/ext/text/text.go
@@ -205,6 +205,20 @@ func (txt *Text) Unaligned() *Text {
 	return txt
 }
 
+func (txt *Text) AnchoredBounds() pixel.Rect {
+	if !txt.isAnchored {
+		return txt.bounds
+	}
+	return txt.bounds.Moved(txt.AnchoredOffset())
+}
+
+func (txt *Text) AnchoredDot() pixel.Vec {
+	if !txt.isAnchored {
+		return txt.Dot
+	}
+	return txt.AnchoredOffset().Add(txt.Dot)
+}
+
 func (txt *Text) AnchoredOffset() pixel.Vec {
 	if !txt.isAnchored {
 		return pixel.ZV


### PR DESCRIPTION
Anchoring was not working properly for multiline text because of the way text.Orig and text.bounds are aligned. Orig is at the bottom of the first line, and bounds are extended downward after each `\n` character. For a single line of text, Orig is effectively at bounds.Min, so anchoring relative to bounds works as expected. However after one or more line breaks there is a growing offset between Orig and bounds.Min and the anchor vec from bounds is no longer correctly aligned.

In order to preserve the previous behavior of text, in which characters are drawn starting at the origin and expanding right and down, the anchor offset is disabled by default until `AlignedTo(...)` is called. Otherwise now that anchoring is correctly computed text would shift up after each newline since the default anchor value is TopRight (a.k.a `pixel.Anchor{0, 0}`).

# Broken anchoring
![image](https://github.com/user-attachments/assets/7c024385-8042-43fa-91bf-0fba67b37a66)

Here the anchor is set to pixel.Center, but instead of being centered on Orig, it is anchored to un-untransformed bounds.Min, so the entire text moves down after every line break. Additionally, there is no convenient way to get the true bounds or Dot of the text in anchor-space, since anchoring is applied at draw time.

![image](https://github.com/user-attachments/assets/5db3667d-71da-49bc-90cd-c0b037428ad2)
Here there are a number of `\n` and `\t` characters entered first before entering text. Because bounds did not account for them, the anchoring is not aligned to Orig.

# Fixed anchoring
After offsetting the anchor vec by the height minus the first line, anchoring works as expected. I have also added `AnchoredBounds()` and `AnchoredDot()` convenience functions to easily retrieve their positions in anchor-space.

### Centered on Orig
![image](https://github.com/user-attachments/assets/b3175ff3-007b-4db7-987b-3cccf1c41b70)

### Compute bounds/anchoring corrrectly for control characters `\n` and `\t`
Previously bounds were not expanded for line break and tab characters, which could throw off the anchoring.
Anchored to the top right corner (or pixel.BottomLeft for... reasons?)
![image](https://github.com/user-attachments/assets/92fedf21-dff6-4953-8853-969556d02369)

### Compute bounds for space characters when font atlas returns empty rect
Some text fonts return empty bounds for the space character, meaning text that starts with space would not start it's bounds until after the first non-space rune. Again, throwing off the anchoring from what would be expected.
Anchored to bottom left corner (pixel.TopRight)
![image](https://github.com/user-attachments/assets/626f765c-3775-4d4d-88de-b1ae034beb4c)


### Unanchored text

![image](https://github.com/user-attachments/assets/6cdbbf27-6e76-4d1f-8471-378587db6301)
