### PR TITLE
allow text atlas to be exported and replaced to support batching

### DIFF
--- a/ext/text/atlas.go
+++ b/ext/text/atlas.go
@@ -105,7 +105,8 @@ func (a *Atlas) Picture() pixel.Picture {
 	return a.pic
 }
 
-// PictureDataCopy returns a full copy of the underlying picture data of the Atlas.
+// PictureDataCopy returns a deep copy of the atlas's underlying pixel data. The caller
+// owns the returned PictureData and may modify it without affecting the Atlas.
 func (a *Atlas) PictureDataCopy() *pixel.PictureData {
 	newPic := &pixel.PictureData{
 		Stride: a.pic.Stride,
@@ -116,10 +117,16 @@ func (a *Atlas) PictureDataCopy() *pixel.PictureData {
 	return newPic
 }
 
-// CloneWithPictureData returns a new Atlas with the same glyphs but utilizing the supplied PictureData
+// CloneWithPictureData returns a new Atlas that uses pic as its backing image.
+// frame is the sub-rectangle of pic where the atlas glyphs live; it must have
+// the same width and height as the original atlas picture. All glyph coordinates
+// are translated so they remain correct relative to the new location in pic.
+//
+// The intended use is to blit PictureDataCopy into a larger shared atlas image and
+// then call CloneWithPictureData so text can share a pixel.Batch with other sprites.
 func (a *Atlas) CloneWithPictureData(pic *pixel.PictureData, frame pixel.Rect) *Atlas {
 	if a.pic.Bounds().W() != frame.W() || a.pic.Bounds().H() != frame.H() {
-		panic("atlas: new frame dimensions do no match prior picture")
+		panic("atlas: new frame dimensions do not match prior picture")
 	}
 	if !pic.Bounds().Contains(frame.Min) || !pic.Bounds().Contains(frame.Max) {
 		panic("atlas: new frame is out of bounds of supplied pic")

--- a/ext/text/atlas.go
+++ b/ext/text/atlas.go
@@ -2,6 +2,7 @@ package text
 
 import (
 	"image"
+	"image/color"
 	"image/draw"
 	"sort"
 	"unicode"
@@ -24,7 +25,7 @@ type Glyph struct {
 // Atlas is a set of pre-drawn glyphs of a fixed set of runes. This allows for efficient text drawing.
 type Atlas struct {
 	face       font.Face
-	pic        pixel.Picture
+	pic        *pixel.PictureData
 	mapping    map[rune]Glyph
 	ascent     float64
 	descent    float64
@@ -102,6 +103,52 @@ func NewAtlas(face font.Face, runeSets ...[]rune) *Atlas {
 // within the Atlas.
 func (a *Atlas) Picture() pixel.Picture {
 	return a.pic
+}
+
+// PictureDataCopy returns a full copy of the underlying picture data of the Atlas.
+func (a *Atlas) PictureDataCopy() *pixel.PictureData {
+	newPic := &pixel.PictureData{
+		Stride: a.pic.Stride,
+		Rect:   a.pic.Rect,
+		Pix:    make([]color.RGBA, len(a.pic.Pix)),
+	}
+	copy(newPic.Pix, a.pic.Pix)
+	return newPic
+}
+
+// CloneWithPictureData returns a new Atlas with the same glyphs but utilizing the supplied PictureData
+func (a *Atlas) CloneWithPictureData(pic *pixel.PictureData, frame pixel.Rect) *Atlas {
+	if a.pic.Bounds().W() != frame.W() || a.pic.Bounds().H() != frame.H() {
+		panic("atlas: new frame dimensions do no match prior picture")
+	}
+	if !pic.Bounds().Contains(frame.Min) || !pic.Bounds().Contains(frame.Max) {
+		panic("atlas: new frame is out of bounds of supplied pic")
+	}
+	newAtlas := &Atlas{
+		face:       a.face,
+		pic:        pic,
+		mapping:    make(map[rune]Glyph, len(a.mapping)),
+		ascent:     a.ascent,
+		descent:    a.descent,
+		lineHeight: a.lineHeight,
+	}
+	// account for non (0,0) origin images
+	picFrameDelta := frame.Min.Sub(a.pic.Rect.Min)
+	// for each glyph, translate the dot and frame to account for the new frame location within the supplied pic
+	for r, glyph := range a.mapping {
+		rMin := glyph.Frame.Min.Add(picFrameDelta)
+		rMax := rMin.Add(pixel.V(glyph.Frame.W(), glyph.Frame.H()))
+		newFrame := pixel.Rect{
+			Min: rMin,
+			Max: rMax,
+		}
+		newAtlas.mapping[r] = Glyph{
+			Dot:     glyph.Dot.Add(picFrameDelta),
+			Frame:   newFrame,
+			Advance: glyph.Advance,
+		}
+	}
+	return newAtlas
 }
 
 // Contains reports wheter r in contained within the Atlas.

--- a/ext/text/atlas_test.go
+++ b/ext/text/atlas_test.go
@@ -1,8 +1,10 @@
 package text_test
 
 import (
+	"image/color"
 	"testing"
 
+	"github.com/gopxl/pixel/v2"
 	"github.com/gopxl/pixel/v2/ext/text"
 	"golang.org/x/image/font/inconsolata"
 )
@@ -26,4 +28,116 @@ func TestAtlas7x13(t *testing.T) {
 
 func TestAtlasInconsolata(t *testing.T) {
 	text.NewAtlas(inconsolata.Regular8x16, text.ASCII)
+}
+
+func TestAtlasPictureDataCopy(t *testing.T) {
+	a := text.NewAtlas(inconsolata.Regular8x16, text.ASCII)
+	orig := a.Picture().(*pixel.PictureData)
+
+	cp := a.PictureDataCopy()
+	if cp == orig {
+		t.Fatal("PictureDataCopy returned the same pointer as the original")
+	}
+	if cp.Stride != orig.Stride {
+		t.Errorf("Stride mismatch: got %d, want %d", cp.Stride, orig.Stride)
+	}
+	if cp.Rect != orig.Rect {
+		t.Errorf("Rect mismatch: got %v, want %v", cp.Rect, orig.Rect)
+	}
+	if len(cp.Pix) != len(orig.Pix) {
+		t.Fatalf("Pix length mismatch: got %d, want %d", len(cp.Pix), len(orig.Pix))
+	}
+	// Verify deep copy: mutating the copy does not affect the original.
+	if len(cp.Pix) > 0 {
+		origPix := orig.Pix[0]
+		cp.Pix[0] = color.RGBA{R: ^origPix.R, G: ^origPix.G, B: ^origPix.B, A: ^origPix.A}
+		if orig.Pix[0] != origPix {
+			t.Error("PictureDataCopy is not a deep copy: mutating the copy affected the original")
+		}
+	}
+}
+
+func TestAtlasCloneWithPictureData(t *testing.T) {
+	a := text.NewAtlas(inconsolata.Regular8x16, text.ASCII)
+	tests := []struct {
+		name         string
+		offset       pixel.Vec
+		shouldPanic  bool
+		panicMessage string
+	}{
+		{
+			name:   "identity (frame == original bounds)",
+			offset: pixel.ZV,
+		},
+		{
+			name:   "translated into larger shared picture",
+			offset: pixel.V(50, 30),
+		},
+		{
+			name:         "wrong frame size panics",
+			shouldPanic:  true,
+			panicMessage: "atlas: new frame dimensions do not match prior picture",
+		},
+	}
+
+	origBounds := a.Picture().Bounds()
+	origW, origH := origBounds.W(), origBounds.H()
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.shouldPanic {
+				defer func() {
+					r := recover()
+					if r == nil {
+						t.Fatal("expected panic, got none")
+					}
+					if msg, ok := r.(string); !ok || msg != tt.panicMessage {
+						t.Errorf("wrong panic: %v", r)
+					}
+				}()
+				// Supply a frame with wrong dimensions.
+				wrongPic := pixel.MakePictureData(pixel.R(0, 0, origW+1, origH))
+				wrongFrame := pixel.R(0, 0, origW+1, origH)
+				a.CloneWithPictureData(wrongPic, wrongFrame)
+				return
+			}
+
+			// Build a shared picture large enough to hold the atlas at the given offset.
+			sharedW := origW + tt.offset.X
+			sharedH := origH + tt.offset.Y
+			sharedPic := pixel.MakePictureData(pixel.R(0, 0, sharedW, sharedH))
+			frame := pixel.R(tt.offset.X, tt.offset.Y, tt.offset.X+origW, tt.offset.Y+origH)
+
+			clone := a.CloneWithPictureData(sharedPic, frame)
+
+			// The clone must contain every rune the original does.
+			for _, r := range text.ASCII {
+				if !clone.Contains(r) {
+					t.Errorf("clone does not contain rune %q", r)
+				}
+			}
+
+			// Glyph coordinates must be shifted by the frame offset relative to
+			// the original atlas origin.
+			delta := frame.Min.Sub(origBounds.Min)
+			for _, r := range text.ASCII {
+				if !a.Contains(r) {
+					continue
+				}
+				origGlyph := a.Glyph(r)
+				cloneGlyph := clone.Glyph(r)
+				wantDot := origGlyph.Dot.Add(delta)
+				if cloneGlyph.Dot != wantDot {
+					t.Errorf("rune %q: Dot got %v, want %v", r, cloneGlyph.Dot, wantDot)
+				}
+				wantFrame := origGlyph.Frame.Moved(delta)
+				if cloneGlyph.Frame != wantFrame {
+					t.Errorf("rune %q: Frame got %v, want %v", r, cloneGlyph.Frame, wantFrame)
+				}
+				if cloneGlyph.Advance != origGlyph.Advance {
+					t.Errorf("rune %q: Advance got %v, want %v", r, cloneGlyph.Advance, origGlyph.Advance)
+				}
+			}
+		})
+	}
 }


### PR DESCRIPTION
## Problem

`text.NewAtlas` renders a font into a private `*pixel.PictureData`. Drawing text with `pixel.Batch` requires all sprites and glyphs to share the same backing picture, but there was no way to read the atlas image or create an atlas that references a larger shared picture.

## Changes

- `Atlas.PictureDataCopy` — returns a deep copy of the atlas's pixel data so callers can blit it into a shared atlas image.
- `Atlas.CloneWithPictureData(pic, frame)` — returns a new `Atlas` backed by `pic`, with all glyph coordinates translated so they remain correct at their new location (`frame`) within the shared image.
- `Atlas.pic` narrowed from `pixel.Picture` to `*pixel.PictureData` (internal only - the exported `Picture()` method signature is unchanged).

## Usage

```go
// Build a font atlas and copy its pixels into a shared sprite sheet.
fontAtlas := text.NewAtlas(face, text.ASCII)
atlasCopy := fontAtlas.PictureDataCopy()

x, y := 100, 200
placement := image.Rect(x, y, x+int(atlasCopy.Bounds().W()), y+int(atlasCopy.Bounds().H()))
sharedImage := image.NewRGBA(image.Rect(0, 0, 1024, 1024))
draw.Draw(sharedImage, placement, atlasCopy.Image(), atlasCopy.Image().Bounds().Min, draw.Src)
// ... add more sprites to sharedImage

sharedPic := pixel.PictureDataFromImage(sharedImage)
frame := pixel.R(float64(x), float64(y), float64(placement.Max.X), float64(placement.Max.Y))
sharedAtlas := fontAtlas.CloneWithPictureData(sharedPic, frame)

// Now text and sprites can share a single pixel.Batch.
batch := pixel.NewBatch(nil, sharedPic)
textDrawer := text.New(pixel.ZV, sharedAtlas)
textDrawer.WriteString("hello")
textDrawer.Draw(batch, pixel.IM)
batch.Draw(win)
```

## Test plan

- [x] `go build ./...` unchanged.
- [x] `go test ./ext/text/...` — new tests cover deep-copy semantics for `PictureDataCopy`, identity and translated placements for `CloneWithPictureData`, and the wrong-dimensions panic.
