### PR TITLE
support uniform textures and other compose methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,2 @@
 test
 .vscode
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 test
 .vscode
+.idea/

--- a/backends/opengl/canvas.go
+++ b/backends/opengl/canvas.go
@@ -51,6 +51,9 @@ func (c *Canvas) SetUniform(name string, value interface{}) {
 	c.shader.SetUniform(name, value)
 }
 
+// SetUniformTexture binds tex to the sampler2D uniform named name on this
+// canvas's fragment shader. unit is the texture unit index (0-based) and
+// must not collide with any other sampler bound on the same canvas.
 func (c *Canvas) SetUniformTexture(name string, tex *glhf.Texture, unit int) {
 	c.shader.SetUniformTexture(name, tex, unit)
 }

--- a/backends/opengl/canvas.go
+++ b/backends/opengl/canvas.go
@@ -4,11 +4,13 @@ import (
 	"fmt"
 	"image/color"
 
+	"github.com/go-gl/gl/v3.3-core/gl"
 	"github.com/go-gl/mathgl/mgl32"
 	"github.com/gopxl/glhf/v2"
 	"github.com/gopxl/mainthread/v2"
-	"github.com/gopxl/pixel/v2"
 	"github.com/pkg/errors"
+
+	"github.com/gopxl/pixel/v2"
 )
 
 // Canvas is an off-screen rectangular BasicTarget and Picture at the same time, that you can draw
@@ -37,7 +39,7 @@ func NewCanvas(bounds pixel.Rect) *Canvas {
 		col: mgl32.Vec4{1, 1, 1, 1},
 	}
 
-	c.shader = NewGLShader(baseCanvasFragmentShader)
+	c.shader = NewGLShader(BaseCanvasFragmentShader)
 	c.SetBounds(bounds)
 	return c
 }
@@ -47,6 +49,10 @@ func NewCanvas(bounds pixel.Rect) *Canvas {
 // to the new value. The value can be a pointer.
 func (c *Canvas) SetUniform(name string, value interface{}) {
 	c.shader.SetUniform(name, value)
+}
+
+func (c *Canvas) SetUniformTexture(name string, tex *glhf.Texture, unit int) {
+	c.shader.SetUniformTexture(name, tex, unit)
 }
 
 // SetFragmentShader allows you to set a new fragment shader on the underlying
@@ -184,6 +190,11 @@ func setBlendFunc(cmp pixel.ComposeMethod) {
 		glhf.BlendFunc(glhf.One, glhf.One)
 	case pixel.ComposeCopy:
 		glhf.BlendFunc(glhf.One, glhf.Zero)
+	case pixel.ComposeMultiply:
+		glhf.BlendFunc(glhf.BlendFactor(gl.DST_COLOR), glhf.Zero)
+	case pixel.ComposeScreen:
+		gl.BlendEquation(gl.FUNC_ADD)
+		gl.BlendFuncSeparate(gl.ONE, gl.ONE_MINUS_SRC_COLOR, gl.ZERO, gl.ONE)
 	default:
 		panic(errors.New("Canvas: invalid compose method"))
 	}
@@ -317,8 +328,13 @@ func (ct *canvasTriangles) draw(tex *glhf.Texture, bounds pixel.Rect) {
 		}
 
 		for loc, u := range ct.shader.uniforms {
+			if u.isSampler && u.tex != nil {
+				gl.ActiveTexture(gl.TEXTURE0 + uint32(u.unit))
+				u.tex.Begin()
+			}
 			ct.shader.s.SetUniformAttr(loc, u.Value())
 		}
+		gl.ActiveTexture(gl.TEXTURE0)
 
 		if tex == nil {
 			ct.vs.Begin()

--- a/backends/opengl/glshader.go
+++ b/backends/opengl/glshader.go
@@ -137,6 +137,10 @@ func (gs *GLShader) SetUniform(name string, value interface{}) {
 	})
 }
 
+// SetUniformTexture binds a sampler2D uniform so that tex is available in the
+// fragment shader as the sampler named name. unit is the texture unit index
+// (0-based); it must be distinct from any other sampler bound on the same
+// shader. The texture is activated and bound each frame before drawing.
 func (gs *GLShader) SetUniformTexture(name string, tex *glhf.Texture, unit int) {
 	unit32 := int32(unit)
 	t, p := getAttrType(unit32)
@@ -148,17 +152,16 @@ func (gs *GLShader) SetUniformTexture(name string, tex *glhf.Texture, unit int) 
 		gs.uniforms[idx].tex = tex
 		gs.uniforms[idx].unit = unit
 		return
-	} else {
-		gs.uniforms = append(gs.uniforms, gsUniformAttr{
-			Name:      name,
-			Type:      t,
-			value:     unit32,
-			ispointer: p,
-			isSampler: true,
-			tex:       tex,
-			unit:      unit,
-		})
 	}
+	gs.uniforms = append(gs.uniforms, gsUniformAttr{
+		Name:      name,
+		Type:      t,
+		value:     unit32,
+		ispointer: p,
+		isSampler: true,
+		tex:       tex,
+		unit:      unit,
+	})
 }
 
 // Value returns the attribute's concrete value. If the stored value

--- a/backends/opengl/glshader.go
+++ b/backends/opengl/glshader.go
@@ -1,6 +1,8 @@
 package opengl
 
 import (
+	"fmt"
+
 	"github.com/go-gl/mathgl/mgl32"
 	"github.com/gopxl/glhf/v2"
 	"github.com/gopxl/mainthread/v2"
@@ -31,6 +33,10 @@ type gsUniformAttr struct {
 	Type      glhf.AttrType
 	value     interface{}
 	ispointer bool
+
+	isSampler bool
+	tex       *glhf.Texture
+	unit      int
 }
 
 const (
@@ -55,7 +61,7 @@ var defaultCanvasVertexFormat = glhf.AttrFormat{
 func NewGLShader(fragmentShader string) *GLShader {
 	gs := &GLShader{
 		vf: defaultCanvasVertexFormat,
-		vs: baseCanvasVertexShader,
+		vs: BaseCanvasVertexShader,
 		fs: fragmentShader,
 	}
 
@@ -120,6 +126,7 @@ func (gs *GLShader) SetUniform(name string, value interface{}) {
 		gs.uniforms[loc].Type = t
 		gs.uniforms[loc].ispointer = p
 		gs.uniforms[loc].value = value
+		gs.uniforms[loc].isSampler = false
 		return
 	}
 	gs.uniforms = append(gs.uniforms, gsUniformAttr{
@@ -128,6 +135,30 @@ func (gs *GLShader) SetUniform(name string, value interface{}) {
 		ispointer: p,
 		value:     value,
 	})
+}
+
+func (gs *GLShader) SetUniformTexture(name string, tex *glhf.Texture, unit int) {
+	unit32 := int32(unit)
+	t, p := getAttrType(unit32)
+	if idx := gs.getUniform(name); idx > -1 {
+		gs.uniforms[idx].Type = t
+		gs.uniforms[idx].value = unit32
+		gs.uniforms[idx].ispointer = p
+		gs.uniforms[idx].isSampler = true
+		gs.uniforms[idx].tex = tex
+		gs.uniforms[idx].unit = unit
+		return
+	} else {
+		gs.uniforms = append(gs.uniforms, gsUniformAttr{
+			Name:      name,
+			Type:      t,
+			value:     unit32,
+			ispointer: p,
+			isSampler: true,
+			tex:       tex,
+			unit:      unit,
+		})
+	}
 }
 
 // Value returns the attribute's concrete value. If the stored value
@@ -231,11 +262,14 @@ func getAttrType(v interface{}) (glhf.AttrType, bool) {
 	case *float32:
 		return glhf.Float, true
 	default:
-		panic("invalid AttrType")
+		if v == nil {
+			panic("invalid AttrType (nil)")
+		}
+		panic(fmt.Sprintf("invalid AttrType: %T value=%#v", v, v))
 	}
 }
 
-var baseCanvasVertexShader = `
+var BaseCanvasVertexShader = `
 #version 330 core
 
 in vec2  aPosition;
@@ -267,7 +301,7 @@ void main() {
 }
 `
 
-var baseCanvasFragmentShader = `
+var BaseCanvasFragmentShader = `
 #version 330 core
 
 in vec4  vColor;

--- a/compose.go
+++ b/compose.go
@@ -83,9 +83,6 @@ func (cm ComposeMethod) Compose(a, b RGBA) RGBA {
 		}
 
 		ao := sa + da - sa*da
-		// (optional) clamp to [0,1]
-		// cr = math.Min(1, math.Max(0, cr)) ... same for cg, cb, ao
-
 		return RGBA{R: cr, G: cg, B: cb, A: ao}
 	case ComposeScreen:
 		sa, da := a.A, b.A

--- a/compose.go
+++ b/compose.go
@@ -27,6 +27,8 @@ const (
 	ComposeXor
 	ComposePlus
 	ComposeCopy
+	ComposeMultiply
+	ComposeScreen
 )
 
 // Compose composes two colors together according to the ComposeMethod. A is the foreground, B is
@@ -57,6 +59,60 @@ func (cm ComposeMethod) Compose(a, b RGBA) RGBA {
 		fa, fb = 1, 1
 	case ComposeCopy:
 		fa, fb = 1, 0
+	case ComposeMultiply:
+		sa, da := a.A, b.A
+
+		// term1: backdrop where source is transparent
+		cr := b.R * (1 - sa)
+		cg := b.G * (1 - sa)
+		cb := b.B * (1 - sa)
+
+		// term2: source where backdrop is transparent
+		cr += a.R * (1 - da)
+		cg += a.G * (1 - da)
+		cb += a.B * (1 - da)
+
+		// blended term: multiply of unpremultiplied colors, then re-premultiply by Sa*Da
+		if sa > 0 && da > 0 {
+			// unpremultiply
+			asr, asg, asb := a.R/sa, a.G/sa, a.B/sa
+			bsr, bsg, bsb := b.R/da, b.G/da, b.B/da
+			cr += (asr * bsr) * sa * da
+			cg += (asg * bsg) * sa * da
+			cb += (asb * bsb) * sa * da
+		}
+
+		ao := sa + da - sa*da
+		// (optional) clamp to [0,1]
+		// cr = math.Min(1, math.Max(0, cr)) ... same for cg, cb, ao
+
+		return RGBA{R: cr, G: cg, B: cb, A: ao}
+	case ComposeScreen:
+		sa, da := a.A, b.A
+
+		// term1: backdrop where source is transparent
+		cr := b.R * (1 - sa)
+		cg := b.G * (1 - sa)
+		cb := b.B * (1 - sa)
+
+		// term2: source where backdrop is transparent
+		cr += a.R * (1 - da)
+		cg += a.G * (1 - da)
+		cb += a.B * (1 - da)
+
+		// blended term: screen of unpremultiplied colors, then re-premultiply by Sa*Da
+		if sa > 0 && da > 0 {
+			// unpremultiply
+			asr, asg, asb := a.R/sa, a.G/sa, a.B/sa
+			bsr, bsg, bsb := b.R/da, b.G/da, b.B/da
+			// screen formula: 1 - (1-as)*(1-bs)
+			cr += (1 - (1-asr)*(1-bsr)) * sa * da
+			cg += (1 - (1-asg)*(1-bsg)) * sa * da
+			cb += (1 - (1-asb)*(1-bsb)) * sa * da
+		}
+
+		ao := sa + da - sa*da
+		return RGBA{R: cr, G: cg, B: cb, A: ao}
 	default:
 		panic(errors.New("Compose: invalid ComposeMethod"))
 	}

--- a/tests/compose_test.go
+++ b/tests/compose_test.go
@@ -1,0 +1,104 @@
+package pixel_test
+
+import (
+	"math"
+	"testing"
+
+	"github.com/gopxl/pixel/v2"
+)
+
+func approxEq(a, b, eps float64) bool {
+	return math.Abs(a-b) <= eps
+}
+
+func rgbaApproxEq(a, b pixel.RGBA, eps float64) bool {
+	return approxEq(a.R, b.R, eps) &&
+		approxEq(a.G, b.G, eps) &&
+		approxEq(a.B, b.B, eps) &&
+		approxEq(a.A, b.A, eps)
+}
+
+func TestComposeMultiply(t *testing.T) {
+	const eps = 1e-9
+	tests := []struct {
+		name string
+		a, b pixel.RGBA
+		want pixel.RGBA
+	}{
+		{
+			name: "both opaque - multiply channels",
+			a:    pixel.RGBA{R: 0.5, G: 0.5, B: 0.5, A: 1},
+			b:    pixel.RGBA{R: 0.8, G: 0.4, B: 1.0, A: 1},
+			want: pixel.RGBA{R: 0.4, G: 0.2, B: 0.5, A: 1},
+		},
+		{
+			name: "white source over opaque bg - unchanged",
+			a:    pixel.RGBA{R: 1, G: 1, B: 1, A: 1},
+			b:    pixel.RGBA{R: 0.6, G: 0.3, B: 0.9, A: 1},
+			want: pixel.RGBA{R: 0.6, G: 0.3, B: 0.9, A: 1},
+		},
+		{
+			name: "black source - all black",
+			a:    pixel.RGBA{R: 0, G: 0, B: 0, A: 1},
+			b:    pixel.RGBA{R: 0.6, G: 0.3, B: 0.9, A: 1},
+			want: pixel.RGBA{R: 0, G: 0, B: 0, A: 1},
+		},
+		{
+			name: "transparent source - backdrop unchanged",
+			a:    pixel.RGBA{R: 0, G: 0, B: 0, A: 0},
+			b:    pixel.RGBA{R: 0.6, G: 0.3, B: 0.9, A: 1},
+			want: pixel.RGBA{R: 0.6, G: 0.3, B: 0.9, A: 1},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pixel.ComposeMultiply.Compose(tt.a, tt.b)
+			if !rgbaApproxEq(got, tt.want, eps) {
+				t.Errorf("ComposeMultiply.Compose(%v, %v) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestComposeScreen(t *testing.T) {
+	const eps = 1e-9
+	tests := []struct {
+		name string
+		a, b pixel.RGBA
+		want pixel.RGBA
+	}{
+		{
+			name: "both opaque - screen formula: 1-(1-a)*(1-b)",
+			a:    pixel.RGBA{R: 0.5, G: 0.5, B: 0.5, A: 1},
+			b:    pixel.RGBA{R: 0.5, G: 0.5, B: 0.5, A: 1},
+			// 1 - 0.5*0.5 = 0.75
+			want: pixel.RGBA{R: 0.75, G: 0.75, B: 0.75, A: 1},
+		},
+		{
+			name: "black source - backdrop unchanged",
+			a:    pixel.RGBA{R: 0, G: 0, B: 0, A: 1},
+			b:    pixel.RGBA{R: 0.6, G: 0.3, B: 0.9, A: 1},
+			want: pixel.RGBA{R: 0.6, G: 0.3, B: 0.9, A: 1},
+		},
+		{
+			name: "white source - output is white",
+			a:    pixel.RGBA{R: 1, G: 1, B: 1, A: 1},
+			b:    pixel.RGBA{R: 0.6, G: 0.3, B: 0.9, A: 1},
+			want: pixel.RGBA{R: 1, G: 1, B: 1, A: 1},
+		},
+		{
+			name: "transparent source - backdrop unchanged",
+			a:    pixel.RGBA{R: 0, G: 0, B: 0, A: 0},
+			b:    pixel.RGBA{R: 0.6, G: 0.3, B: 0.9, A: 1},
+			want: pixel.RGBA{R: 0.6, G: 0.3, B: 0.9, A: 1},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := pixel.ComposeScreen.Compose(tt.a, tt.b)
+			if !rgbaApproxEq(got, tt.want, eps) {
+				t.Errorf("ComposeScreen.Compose(%v, %v) = %v, want %v", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Changes

Two independent additions to the opengl backend.

### Sampler uniforms (`SetUniformTexture`)

`Canvas.SetUniformTexture(name, tex, unit)` binds a `*glhf.Texture` to a named `sampler2D` in the canvas's fragment shader. The texture is activated on the given unit and bound each frame during draw.

```go
var overlayTex *glhf.Texture  // e.g. a normal map or light mask
canvas.SetFragmentShader(myShaderSrc)
canvas.SetUniformTexture("uOverlay", overlayTex, 0)
```

In the shader:
```glsl
uniform sampler2D uTexture;  // pixel's built-in sprite texture
uniform sampler2D uOverlay;

void main() {
    vec4 base = texture(uTexture, vTexCoords);
    vec4 mask = texture(uOverlay, vTexCoords);
    fragColor = base * mask;
}
```

The two default shader constants are now exported (`BaseCanvasVertexShader`, `BaseCanvasFragmentShader`) so custom shaders can extend the defaults without duplicating the source.

### Compose methods

Two new Porter-Duff composition modes for `canvas.SetComposeMethod`:

- `pixel.ComposeMultiply` — multiplies source and destination channels. Useful for lighting masks: https://www.slembcke.net/blog/2DLightingTechniques#screen-space-lightmaps
- `pixel.ComposeScreen` — inverse of multiply; lightens by `1-(1-src)*(1-dst)`.

Both modes have software implementations in `Compose()` and hardware blend function registrations in the opengl backend. The hardware path uses raw `go-gl/gl` calls for `BlendEquation` and `BlendFuncSeparate` since glhf v2.0.0 does not yet expose those wrappers (the companion glhf PR #8 adds them — once that lands these can be simplified).

## Test plan

- [x] `go build ./...` unchanged.
- [x] `go test ./...` — new `tests/compose_test.go` covers `ComposeMultiply` and `ComposeScreen` with opaque, transparent, black, and white inputs.
